### PR TITLE
Add FoundRole to Global

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Remote jobs from all over the world
 1. AuthenticJobs: [https://www.authenticjobs.com/](https://www.authenticjobs.com/?ref=rogeroba)
 1. ClojureJobBoard: [https://www.clojurejobboard.com](https://www.clojurejobboard.com?ref=rogeroba) - Clojure jobs, also got a remote section
 1. FlexJobs: [https://www.flexjobs.com/](https://www.flexjobs.com/?ref=rogeroba)
+1. FoundRole: [https://www.foundrole.com/](https://www.foundrole.com/) - AI job search with built-in tracker
 1. GolangProjects: [https://www.golangprojects.com/golang-remote-jobs.html](https://www.golangprojects.com/golang-remote-jobs.html?ref=rogeroba)
 1. Himalayas: [https://himalayas.app](https://himalayas.app?ref=rogeroba)
 1. HNHiring: [http://hnhiring.me/](http://hnhiring.me/?ref=rogeroba)


### PR DESCRIPTION
## What is FoundRole?

FoundRole is a free AI job search platform for job seekers who want search, tracking, and career tools in one place. It combines an AI-powered job search engine with a Kanban application tracker and market analytics — replacing the spreadsheets and browser tabs most candidates use today. All core features are free, with no credit-card walls.

**What makes it different:**

- AI-native search — AI is the primary interface, not an add-on
- Built-in Kanban tracker so applications never get lost across tabs
- MCP integration for Claude and ChatGPT — search live jobs directly from AI chat
- Free-first model — core tools free forever

**Why the Global section:** FoundRole is a general-purpose job search platform open to all locations and job types, consistent with the other global boards (FlexJobs, Himalayas, JustRemote) already listed in this section.