### PR TITLE
Add Jobs in JavaScript to the Global list

### DIFF
--- a/data_sources.json
+++ b/data_sources.json
@@ -365,6 +365,14 @@
       "categories": [
         "global"
       ]
+    },
+    {
+      "name": "Jobs in JavaScript",
+      "url": "https://jobsinjs.com/remote-javascript-jobs/",
+      "short_description": "Remote JavaScript, TypeScript and Node.js roles, updated daily",
+      "categories": [
+        "global"
+      ]
     }
   ],
   "tools": [


### PR DESCRIPTION
Added Jobs in JavaScript to the `global` category in `data_sources.json`.

Jobs in JavaScript covers remote JavaScript, TypeScript and Node.js roles. Listings are refreshed daily and aggregated from company career pages across Greenhouse, Workable, JazzHR, AshbyHQ and other ATS platforms.

Free to browse, no account required.
